### PR TITLE
Add mode to stack cameras together (Refactor yield mode)

### DIFF
--- a/tensorflow_datasets/core/dataset_builder.py
+++ b/tensorflow_datasets/core/dataset_builder.py
@@ -460,7 +460,7 @@ class DatasetBuilder(registered.RegisteredDataset):
       *,
       batch_size: Optional[int] = None,
       shuffle_files: bool = False,
-      decoders: Optional[TreeDict[decode.Decoder]] = None,
+      decoders: Optional[TreeDict[decode.partial_decode.DecoderArg]] = None,
       read_config: Optional[read_config_lib.ReadConfig] = None,
       as_supervised: bool = False,
   ):
@@ -571,7 +571,7 @@ class DatasetBuilder(registered.RegisteredDataset):
       split,
       shuffle_files,
       batch_size,
-      decoders,
+      decoders: Optional[TreeDict[decode.partial_decode.DecoderArg]],
       read_config,
       as_supervised,
   ):
@@ -787,11 +787,13 @@ class DatasetBuilder(registered.RegisteredDataset):
     raise NotImplementedError
 
   @abc.abstractmethod
-  def _as_dataset(self,
-                  split,
-                  decoders=None,
-                  read_config=None,
-                  shuffle_files=False):
+  def _as_dataset(
+      self,
+      split,
+      decoders: Optional[TreeDict[decode.partial_decode.DecoderArg]] = None,
+      read_config=None,
+      shuffle_files=False,
+  ):
     """Constructs a `tf.data.Dataset`.
 
     Internal implementation to overwrite when inheriting from DatasetBuilder.
@@ -927,7 +929,7 @@ class FileReaderBuilder(DatasetBuilder):
   def _as_dataset(
       self,
       split,
-      decoders,
+      decoders: Optional[TreeDict[decode.partial_decode.DecoderArg]],
       read_config,
       shuffle_files,
   ) -> tf.data.Dataset:

--- a/tensorflow_datasets/core/decode/partial_decode.py
+++ b/tensorflow_datasets/core/decode/partial_decode.py
@@ -26,7 +26,9 @@ from tensorflow_datasets.core.features import features_dict
 
 # Expected feature specs provided by the user
 _FeatureSpecElem = Union[features_lib.FeatureConnector, Any]
-_FeatureSpecs = utils.TreeDict[_FeatureSpecElem]
+FeatureSpecs = utils.TreeDict[_FeatureSpecElem]
+
+DecoderArg = Union[base.Decoder, 'PartialDecoding']
 
 
 class PartialDecoding:
@@ -39,7 +41,7 @@ class PartialDecoding:
 
   def __init__(
       self,
-      features: _FeatureSpecs,
+      features: FeatureSpecs,
       decoders: Optional[utils.TreeDict[base.Decoder]] = None,
   ):
     """Constructor.
@@ -83,8 +85,8 @@ class PartialDecoding:
 
 def _normalize_feature_item(
     feature: features_lib.FeatureConnector,
-    expected_feature: _FeatureSpecs,
-) -> _FeatureSpecs:
+    expected_feature: FeatureSpecs,
+) -> FeatureSpecs:
   """Extract the features matching the expected_feature structure."""
   # If user provide a FeatureConnector, use this
   if isinstance(expected_feature,
@@ -109,8 +111,8 @@ def _normalize_feature_item(
 
 def _normalize_feature_dict(
     feature: features_lib.FeatureConnector,
-    expected_feature: _FeatureSpecs,
-) -> _FeatureSpecs:
+    expected_feature: FeatureSpecs,
+) -> FeatureSpecs:
   """Extract the features matching the expected_feature structure."""
   if type(feature) == features_lib.FeaturesDict:  # pylint: disable=unidiomatic-typecheck
     inner_features = {

--- a/tensorflow_datasets/core/load.py
+++ b/tensorflow_datasets/core/load.py
@@ -201,7 +201,7 @@ def load(
     shuffle_files: bool = False,
     download: bool = True,
     as_supervised: bool = False,
-    decoders: Optional[TreeDict[decode.Decoder]] = None,
+    decoders: Optional[TreeDict[decode.partial_decode.DecoderArg]] = None,
     read_config: Optional[read_config_lib.ReadConfig] = None,
     with_info: bool = False,
     builder_kwargs: Optional[Dict[str, Any]] = None,

--- a/tensorflow_datasets/typing.py
+++ b/tensorflow_datasets/typing.py
@@ -15,6 +15,7 @@
 
 """TFDS typing annotations."""
 
+from tensorflow_datasets.core import decode
 from tensorflow_datasets.core import splits
 from tensorflow_datasets.core.features import feature
 from tensorflow_datasets.core.utils import type_utils
@@ -23,10 +24,14 @@ from tensorflow_datasets.core.utils import type_utils
 from tensorflow_datasets.core.utils.type_utils import *  # pylint: disable=wildcard-import
 # pylint: enable=unused-import
 
+DecoderArg = decode.partial_decode.DecoderArg
+FeatureSpecs = decode.partial_decode.FeatureSpecs
 FeatureConnectorArg = feature.FeatureConnectorArg
 SplitArg = splits.SplitArg
 
 __all__ = type_utils.__all__ + [
+    'DecoderArg',
     'FeatureConnectorArg',
+    'FeatureSpecs',
     'SplitArg',
 ]


### PR DESCRIPTION
Simplify the sunds API:

* Merge yield_individual_camera & keep_image into a new yield_mode argument which can be:
   * 'ray'
   * 'image'
   * 'stacked'
   * 'dict'

* Rearrange operation order to avoid edge cases (e.g. only unpack dict -> image at the end of the pipeline)

PiperOrigin-RevId: 413722550

Thank you for your contribution!

Please read https://www.tensorflow.org/datasets/contribute#pr_checklist to make sure your PR follows the guidelines.

# Add Dataset

* Dataset Name: <name>
* Issue Reference: <link>
* `dataset_info.json` Gist: <link>

## Description

<description>

## Checklist

* [x] Address all TODO's
* [x] Add alphabetized import to subdirectory's `__init__.py`
* [x] Run `download_and_prepare` successfully
* [x] Add [checksums file](https://www.tensorflow.org/datasets/add_dataset#2_run_download_and_prepare_locally)
* [x] Properly cite in `BibTeX` format
* [x] Add passing test(s)
* [x] Add test data
* [x] If using additional dependencies (e.g. `scipy`), use [lazy_imports](https://www.tensorflow.org/datasets/add_dataset#extra_dependencies) (if applicable)
* [x] Add data generation script (if applicable)
* [x] [Lint](https://www.tensorflow.org/datasets/add_dataset#5_check_your_code_style) code
